### PR TITLE
Fixed two minor typos in the documentation.

### DIFF
--- a/docs/api/references/plugin_api/classes/joplin.html
+++ b/docs/api/references/plugin_api/classes/joplin.html
@@ -69,7 +69,7 @@
 					<div class="lead">
 						<p>This is the main entry point to the Joplin API. You can access various services using the provided accessors.</p>
 					</div>
-					<p>The API is now relatively stable and in general maintaining backward compatibility is a top priority, so you shouldn&#39;t except much breakages.</p>
+					<p>The API is now relatively stable and in general maintaining backward compatibility is a top priority, so you shouldn&#39;t expect much breakages.</p>
 					<p>If a breaking change ever becomes needed, best effort will be done to:</p>
 					<ul>
 						<li>Deprecate features instead of removing them, so as to give you time to fix the issue;</li>

--- a/docs/api/references/plugin_api/classes/joplinworkspace.html
+++ b/docs/api/references/plugin_api/classes/joplinworkspace.html
@@ -279,7 +279,7 @@
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Called when a resource is changed. Currently this handled will not be
+									<p>Called when a resource is changed. Currently this handler will not be
 									called when a resource is added or deleted.</p>
 								</div>
 							</div>


### PR DESCRIPTION
Hello, I was reading the plugin documentation and saw what I believe are a couple of small typos. I've corrected them in this pull request. 

I see in the readme for this repo that the site is generated every six hours so I hope I haven't directly edited files that shouldn't be. Neither had a header saying they are auto-generated so just let me know.