### PR TITLE
Build and include the plugin website: Just one workflow job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,14 @@ jobs:
           ref: master
           ssh-key: ${{ secrets.JOPLIN_BOT_SSH_PRIVATE_KEY }}
           path: 'joplin-website'
+    
+      - name: Checkout Joplin plugin website repository
+        uses: actions/checkout@v2
+        with:
+          repository: 'joplin/website-plugin-discovery'
+          ref: main
+          ssh-key: ${{ secrets.JOPLIN_BOT_SSH_PRIVATE_KEY }}
+          path: 'website-plugin-discovery'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This pull request is similar to https://github.com/joplin/website/pull/5, but doesn't isolate the plugin website build in a separate job.

See https://github.com/laurent22/joplin/pull/9471