### PR TITLE
Build: Upgrade to node 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,9 @@ jobs:
           sudo apt-get install -y libsecret-1-dev
 
       - name: Install Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
 
       - name: Release website
         env:


### PR DESCRIPTION
# Summary

Node 16 is end-of-life and doesn't support `readline/promises`, which is used by the default plugins build script.

This pull request upgrades CI to the current LTS version of Node.