### PR TITLE
Fix website build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Build
         shell: bash
         run: |
+          corepack enable
           cd website-plugin-discovery
           yarn install
           yarn build-production /plugins


### PR DESCRIPTION
# Summary

This pull request should fix the website build.

# Explanation

This [pull request](https://github.com/joplin/website-plugin-discovery/pull/50) upgraded the plugin website from Yarn v1 to Yarn v4 in part by setting the `packageManager` field in `package.json`. This requires `corepack` to have been `enable`d.


See the relevant error message in the build output:
```
error This project's package.json defines "packageManager": "yarn@4.5.0". However the current global version of Yarn is 1.22.22.

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
```