### PR TITLE
Chore: Upgrade workflow versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       # Send to the main website workflow.
       # See https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow
       - name: Upload built plugins
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: plugin-website
           path: plugin-website.tar.gz
@@ -64,7 +64,7 @@ jobs:
           path: 'joplin-website'
 
       - name: Download built plugin website
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: plugin-website
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Joplin plugin website repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'joplin/website-plugin-discovery'
           ref: main
@@ -48,7 +48,7 @@ jobs:
     steps:
 
       - name: Checkout main Joplin repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'laurent22/joplin'
           ref: dev
@@ -56,7 +56,7 @@ jobs:
           path: 'joplin'
 
       - name: Checkout Joplin website repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'joplin/website'
           ref: master


### PR DESCRIPTION
# Summary

This pull request upgrades `actions/upload-artifact`, `actions/download-artifact`, and `actions/checkout` to v4.

Fixes https://github.com/joplin/website/issues/12.

# Changes in major releases

**Note**: Only the changes associated with major version increases are listed below:

## actions/checkout

[**v4**](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400):
> Support fetching without the --progress option
> Update to node20

[**v3**](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v300):
>
> Upgrade to Node 16

## actions/upload-artifact

[Breaking changes for v4:](https://github.com/actions/upload-artifact/tree/main?tab=readme-ov-file#breaking-changes)
<blockquote>
Breaking Changes

    On self hosted runners, additional [firewall rules](https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes) may be required.

    Uploading to the same named Artifact multiple times.

    Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

    Limit of Artifacts for an individual job. Each job in a workflow run now has a limit of 500 artifacts.

    With v4.4 and later, hidden files are excluded by default.

For assistance with breaking changes, see [MIGRATION.md](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).
</blockquote>

## actions/download-artifact

[v4 breaking changes:](https://github.com/actions/download-artifact/tree/main?tab=readme-ov-file#breaking-changes)
<blockquote>

On self hosted runners, additional [firewall rules](https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes) may be required.
    Downloading artifacts that were created from action/upload-artifact@v3 and below are not supported.

For assistance with breaking changes, see [MIGRATION.md](https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md).
</blockquote>

# Note

These changes have not been tested locally or in CI.