### PR TITLE
Chore: Update the website without committing to `joplin/website`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       # Send to the main website workflow.
       # See https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow
       - name: Upload built plugins
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: plugin-website
           path: plugin-website.tar.gz
@@ -64,7 +64,7 @@ jobs:
           path: 'joplin-website'
 
       - name: Download built plugin website
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: plugin-website
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Joplin plugin website repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'joplin/website-plugin-discovery'
           ref: main
@@ -48,7 +48,7 @@ jobs:
     steps:
 
       - name: Checkout main Joplin repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'laurent22/joplin'
           ref: dev
@@ -56,7 +56,7 @@ jobs:
           path: 'joplin'
 
       - name: Checkout Joplin website repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: 'joplin/website'
           ref: master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,6 @@ jobs:
         with:
           repository: 'joplin/website'
           ref: master
-          ssh-key: ${{ secrets.JOPLIN_BOT_SSH_PRIVATE_KEY }}
           path: 'joplin-website'
 
       - name: Download built plugin website
@@ -89,3 +88,13 @@ jobs:
             CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
         run: |
           ./joplin/packages/tools/release-website.sh
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'joplin-website/docs/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Summary

Currently, the `joplin/website` repository takes a long time to clone locally, due to the large number of very large commits in its history.

Rather than updating the website by committing, this pull request uses `actions/deploy-pages`. See the [relevant GitHub documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site).

> [!NOTE]
>
> This pull request contains changes from https://github.com/joplin/website/pull/13.

> [!IMPORTANT]
>
> This pull request should be merged with https://github.com/laurent22/joplin/pull/11360.

# Note

After merging, a setting under "Pages" in this repository's settings will need to be changed to "GitHub Actions":
![screenshot: build and deployment source two options one: From branch, another: From GitHub Actions](https://github.com/user-attachments/assets/9935a50e-bb4d-4264-8d71-5fa55eaf02a1)
