### PR TITLE
Chore: Fix GITHUB_TOKEN permission for GitHub pages deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
+# Permissions required for deployment to GitHub pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 jobs:
   # We run the plugin website CI in a separate job that doesn't have
   # SSH key access for extra security because it handles untrusted markdown.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,6 @@ on:
   workflow_dispatch:
 # Permissions required for deployment to GitHub pages
 permissions:
-  contents: read
   pages: write
   id-token: write
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,6 @@ on:
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:
-# Permissions required for deployment to GitHub pages
-permissions:
-  pages: write
-  id-token: write
 jobs:
   # We run the plugin website CI in a separate job that doesn't have
   # SSH key access for extra security because it handles untrusted markdown.
@@ -99,6 +95,15 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: 'joplin-website/docs/'
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: Main
+    permissions:
+      # Permissions needed for pages deployment. See
+      # https://github.com/actions/deploy-pages
+      pages: write
+      id-token: write
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Summary

This pull request attempts to fix a permissions error while deploying to GitHub pages:
```
Ensure GITHUB_TOKEN has permission "id-token: write".
```

This adds the required [permissions described in the deploy-pages action documentation](https://github.com/actions/deploy-pages?tab=readme-ov-file#usage) and, as suggested by the same documentation, moves `deploy-pages` to its own job.